### PR TITLE
Add DiscordRPC to all Platforms

### DIFF
--- a/Android/UI/GameActivity.cs
+++ b/Android/UI/GameActivity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using Android.App;
 using Android.Content;
@@ -8,6 +8,7 @@ using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using AndroidX.AppCompat.App;
+using ScePSX.Core.DiscordRPC;
 
 #pragma warning disable CS8602
 #pragma warning disable CS8618
@@ -74,6 +75,16 @@ namespace ScePSX
         {
             base.OnResume();
             SetFullScreen();
+        }
+
+        protected override void OnPause()
+        {
+            base.OnPause();
+            if (AHelper.MainView != null && AHelper.MainView.PSX != null && AHelper.MainView.PSX.isRun())
+            {
+                AHelper.MainView.PSX.Pause();
+                RPCManager.Instance.SetPaused(true);
+            }
         }
 
         protected override void OnDestroy()

--- a/Android/UI/GameActivityMange.cs
+++ b/Android/UI/GameActivityMange.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using Android.Content;
+using ScePSX.Core.DiscordRPC;
 using static ScePSX.Controller;
 using static ScePSX.VirtualGamepadOverlay;
 
@@ -202,6 +203,7 @@ public class GameActivityMange
         if (PSX.isRun())
         {
             PSX.Stop();
+            RPCManager.Instance.StopGame();
         }
     }
 

--- a/Android/UI/MainView.axaml.cs
+++ b/Android/UI/MainView.axaml.cs
@@ -1,7 +1,8 @@
-﻿using System.IO;
+using System.IO;
 using Android.Content;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using ScePSX.Core.DiscordRPC;
 
 #pragma warning disable CS8602
 #pragma warning disable CS8604
@@ -16,7 +17,7 @@ namespace ScePSX
         public const string Version = "Version 0.2.1.1";
 
         GameActivityMange ActivityMange;
-        PSXHandler PSX;
+        public PSXHandler PSX;
 
         public MainView()
         {
@@ -50,6 +51,8 @@ namespace ScePSX
             ActivityMange = new GameActivityMange();
 
             PSX = ActivityMange.PSX;
+
+            RPCManager.Instance.Initialize();
         }
 
         protected override void OnLoaded(RoutedEventArgs e)
@@ -140,6 +143,14 @@ namespace ScePSX
 
             //var Bios = AHelper.DownloadPath + "/SCPH1001.BIN";
             PSX.LoadGame(file, Bios, id);
+
+            var gameName = PSX.GameName;
+            if (string.IsNullOrEmpty(gameName))
+            {
+                var fileInfo = new FileInfo(file);
+                gameName = Path.GetFileNameWithoutExtension(fileInfo.Name);
+            }
+            RPCManager.Instance.StartGame(gameName, PSX.Core?.DiskID ?? "");
 
             RomListView.FillByini();
         }

--- a/AvaloniaUI/UI/MainWindow.axaml.cs
+++ b/AvaloniaUI/UI/MainWindow.axaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -11,6 +11,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
+using ScePSX.Core.DiscordRPC;
 using ScePSX.Core.GPU;
 
 namespace ScePSX.UI;
@@ -30,49 +31,51 @@ public partial class MainWindow : Window
     [DllImport("kernel32.dll")]
     public static extern Boolean AllocConsole();
 
-    public MainWindow()
-    {
-        InitializeComponent();
-
-        if (OperatingSystem.IsWindows())
+        public MainWindow()
         {
-            if (File.Exists("./opengl32.dll") && !File.Exists("./ReShader.dll"))
+            InitializeComponent();
+
+            if (OperatingSystem.IsWindows())
             {
-                File.Copy("./opengl32.dll", "./ReShader.dll");
+                if (File.Exists("./opengl32.dll") && !File.Exists("./ReShader.dll"))
+                {
+                    File.Copy("./opengl32.dll", "./ReShader.dll");
+                }
             }
+
+            RomList.OnDbClick += RomListSeelected;
+
+            PSX = new PSXHandler();
+
+            this.AddHandler(KeyDownEvent, MainWindow_KeyDown, RoutingStrategies.Tunnel);
+            this.AddHandler(KeyUpEvent, MainWindow_KeyUp, RoutingStrategies.Tunnel);
+
+            this.Closing += MainWindow_Closing;
+
+            CleanCheckSet(MnuRender, (int)PSX.GpuType - 1);
+
+            timer = new DispatcherTimer();
+            timer.Interval = TimeSpan.FromSeconds(1);
+            timer.Tick += Timer_Elapsed;
+            timer.Start();
+
+            SetIcon.EnsureDesktopFile();
+
+            //Translations.CurrentLangId = "en";
+            Translations.DefaultLanguage = "en";
+            Translations.Init();
+            Translations.UpdateLang(this);
+
+            InitLangMenu();
+
+            if (!CheckMac())
+                VulkanMnu.IsVisible = false;
+
+            if (OperatingSystem.IsWindows())
+                ConsoleMnu.IsVisible = true;
+
+            RPCManager.Instance.Initialize();
         }
-
-        RomList.OnDbClick += RomListSeelected;
-
-        PSX = new PSXHandler();
-
-        this.AddHandler(KeyDownEvent, MainWindow_KeyDown, RoutingStrategies.Tunnel);
-        this.AddHandler(KeyUpEvent, MainWindow_KeyUp, RoutingStrategies.Tunnel);
-
-        this.Closing += MainWindow_Closing;
-
-        CleanCheckSet(MnuRender, (int)PSX.GpuType - 1);
-
-        timer = new DispatcherTimer();
-        timer.Interval = TimeSpan.FromSeconds(1);
-        timer.Tick += Timer_Elapsed;
-        timer.Start();
-
-        SetIcon.EnsureDesktopFile();
-
-        //Translations.CurrentLangId = "en";
-        Translations.DefaultLanguage = "en";
-        Translations.Init();
-        Translations.UpdateLang(this);
-
-        InitLangMenu();
-
-        if (!CheckMac())
-            VulkanMnu.IsVisible = false;
-
-        if (OperatingSystem.IsWindows())
-            ConsoleMnu.IsVisible = true;
-    }
 
     protected override void OnLoaded(RoutedEventArgs e)
     {
@@ -110,6 +113,9 @@ public partial class MainWindow : Window
     {
         string PosStr = $"{this.Position.X}|{this.Position.Y}|{(int)this.Width}|{(int)this.Height}";
         PSXHandler.ini.Write("Main", "FromPos", PosStr);
+
+        RPCManager.Instance.StopGame();
+        RPCManager.Instance.Dispose();
     }
 
     private void InitLangMenu()
@@ -449,6 +455,8 @@ public partial class MainWindow : Window
         PSX.GameName = info.Name;
         PSX.LoadGame(info.fullName, info.ID);
 
+        RPCManager.Instance.StartGame(info.Name, PSX.Core?.DiskID ?? "");
+
         InitStateMenu();
     }
 
@@ -464,6 +472,8 @@ public partial class MainWindow : Window
         PSX.SoftDrawView = SoftDrawView;
         PSX.GameName = Path.GetFileNameWithoutExtension(File);
         PSX.LoadGame(File);
+
+        RPCManager.Instance.StartGame(PSX.GameName, PSX.Core?.DiskID ?? "");
 
         InitStateMenu();
     }
@@ -482,6 +492,8 @@ public partial class MainWindow : Window
         PSX.Core.SwapDisk(File);
         PSX.Core.Pauseing = false;
 
+        RPCManager.Instance.StartGame(Path.GetFileNameWithoutExtension(File), PSX.Core.DiskID);
+
         CleanStatus();
         StatusLabel1.Text = $"{Translations.GetText("FrmMain_SwapDisc")} {PSX.Core.DiskID}";
         OSD.Show(StatusLabel1.Text);
@@ -491,6 +503,8 @@ public partial class MainWindow : Window
     private void CloseRomMnu_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
         PSX.Stop();
+
+        RPCManager.Instance.StopGame();
 
         RomListView.FillByini();
 
@@ -520,9 +534,15 @@ public partial class MainWindow : Window
         if (PSX.isRun())
         {
             if (PSX.Core.Pauseed)
+            {
                 PSX.Resume();
+                RPCManager.Instance.SetPaused(false);
+            }
             else
+            {
                 PSX.Pause();
+                RPCManager.Instance.SetPaused(true);
+            }
         }
     }
 

--- a/ScePSX/Core.csproj
+++ b/ScePSX/Core.csproj
@@ -34,4 +34,8 @@
   <EditorConfigFiles Remove=".editorconfig" />
 </ItemGroup>
 
+<ItemGroup>
+  <PackageReference Include="DiscordRichPresence" Version="1.6.1.70" />
+</ItemGroup>
+
 </Project>

--- a/ScePSX/Core/DiscordRPC/RPCManager.cs
+++ b/ScePSX/Core/DiscordRPC/RPCManager.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using DiscordRPC;
+using DiscordRPC.Logging;
+
+namespace ScePSX.Core.DiscordRPC
+{
+    public class RPCManager : IDisposable
+    {
+        private static RPCManager _instance;
+        public static RPCManager Instance => _instance ??= new RPCManager();
+
+        private DiscordRpcClient _client;
+        private bool _initialized = false;
+        private bool _disposed = false;
+
+        private string _gameName = "";
+        private string _diskId = "";
+        private bool _isPaused = false;
+        private Stopwatch _playTimeStopwatch;
+        private string _platformName = "";
+
+        private const string APP_ID = "1342671514892259388";
+
+        public void Initialize()
+        {
+            if (_initialized) return;
+
+            _platformName = GetPlatformName();
+
+            try
+            {
+                _client = new DiscordRpcClient(APP_ID)
+                {
+                    Logger = new ConsoleLogger(LogLevel.Warning, true)
+                };
+
+                _client.OnReady += (sender, e) =>
+                {
+                    Console.WriteLine("[DiscordRPC] Ready! User: {0}", e.User.Username);
+                };
+
+                _client.OnPresenceUpdate += (sender, e) =>
+                {
+                    Console.WriteLine("[DiscordRPC] Presence updated");
+                };
+
+                _client.OnError += (sender, e) =>
+                {
+                    Console.WriteLine("[DiscordRPC] Error: {0} - {1}", e.Code, e.Message);
+                };
+
+                _client.Initialize();
+                _playTimeStopwatch = new Stopwatch();
+                _initialized = true;
+                Console.WriteLine("[DiscordRPC] Initialized successfully on {0}", _platformName);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[DiscordRPC] Failed to initialize: {ex.Message}");
+            }
+        }
+
+        private string GetPlatformName()
+        {
+            if (OperatingSystem.IsWindows())
+                return "Windows";
+            if (OperatingSystem.IsLinux())
+                return "Linux";
+            if (OperatingSystem.IsMacOS())
+                return "macOS";
+            if (OperatingSystem.IsAndroid())
+                return "Android";
+            if (OperatingSystem.IsIOS())
+                return "iOS";
+
+            return RuntimeInformation.OSDescription;
+        }
+
+        public void StartGame(string gameName, string diskId)
+        {
+            if (!_initialized || _client == null) return;
+
+            _gameName = gameName;
+            _diskId = diskId;
+            _isPaused = false;
+            _playTimeStopwatch.Restart();
+
+            UpdatePresence();
+        }
+
+        public void SetPaused(bool paused)
+        {
+            if (!_initialized || _client == null || string.IsNullOrEmpty(_diskId)) return;
+
+            _isPaused = paused;
+
+            if (paused)
+            {
+                _playTimeStopwatch.Stop();
+            }
+            else
+            {
+                _playTimeStopwatch.Start();
+            }
+
+            UpdatePresence();
+        }
+
+        public void StopGame()
+        {
+            if (!_initialized || _client == null) return;
+
+            _playTimeStopwatch.Stop();
+            _client.ClearPresence();
+
+            _gameName = "";
+            _diskId = "";
+            _isPaused = false;
+        }
+
+        private void UpdatePresence()
+        {
+            if (_client == null) return;
+
+            var presence = new RichPresence()
+            {
+                Details = string.IsNullOrEmpty(_gameName) ? "ScePSX" : _gameName,
+                State = _isPaused ? $"Paused | {_platformName}" : $"{FormatPlayTime(_playTimeStopwatch.Elapsed)} | {_platformName}",
+                Timestamps = _isPaused ? new Timestamps() : new Timestamps(DateTime.UtcNow),
+                Assets = new Assets()
+                {
+                    LargeImageKey = "logo",
+                    LargeImageText = "PlayStation 1 Emulator",
+                    SmallImageKey = _isPaused ? "paused" : "playing",
+                    SmallImageText = _isPaused ? "Paused" : "In Game"
+                }
+            };
+
+            if (!string.IsNullOrEmpty(_diskId))
+            {
+                presence.Party = new Party()
+                {
+                    ID = _diskId,
+                    Size = 1,
+                    Max = 1
+                };
+            }
+
+            _client.SetPresence(presence);
+        }
+
+        private string FormatPlayTime(TimeSpan time)
+        {
+            if (time.TotalHours >= 1)
+                return $"Playing for {(int)time.TotalHours}h {time.Minutes}m";
+            else if (time.TotalMinutes >= 1)
+                return $"Playing for {(int)time.TotalMinutes}m {time.Seconds}s";
+            else
+                return "Starting...";
+        }
+
+        public void Shutdown()
+        {
+            if (!_initialized || _client == null) return;
+
+            try
+            {
+                _client.Dispose();
+                _client = null;
+                _initialized = false;
+                Console.WriteLine("[DiscordRPC] Shutdown complete");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[DiscordRPC] Shutdown error: {ex.Message}");
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+
+            if (disposing)
+            {
+                Shutdown();
+            }
+
+            _disposed = true;
+        }
+
+        ~RPCManager()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/WindowUI/UI/Form_Main.cs
+++ b/WindowUI/UI/Form_Main.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Win32;
+using Microsoft.Win32;
+using ScePSX.Core.DiscordRPC;
 using ScePSX.Core.GPU;
 using ScePSX.Render;
 using ScePSX.Win.UI;
@@ -167,6 +168,8 @@ namespace ScePSX.UI
             gpumnu.Enabled = false;
 
             openGLRender.Text = "OpenGL" + Translations.GetText("recommend");
+
+            RPCManager.Instance.Initialize();
         }
 
         private void InitLangMenu()
@@ -217,6 +220,9 @@ namespace ScePSX.UI
         {
             string PosStr = $"{this.Location.X}|{this.Location.Y}|{this.Size.Width}|{this.Size.Height}";
             ini.Write("Main", "FromPos", PosStr);
+
+            RPCManager.Instance.StopGame();
+            RPCManager.Instance.Dispose();
         }
 
         private void UpdateStatus(int index, string text, bool clean = false)
@@ -526,6 +532,8 @@ namespace ScePSX.UI
                 Core = null;
             }
 
+            RPCManager.Instance.StopGame();
+
             romList = new RomList();
             romList.Parent = this;
             romList.Dock = DockStyle.Fill;
@@ -800,7 +808,13 @@ namespace ScePSX.UI
         private void MnuPause_Click(object sender, EventArgs e)
         {
             if (Core != null && Core.Running)
+            {
                 Core.Pause();
+                if (Core.Pauseed)
+                    RPCManager.Instance.SetPaused(true);
+                else
+                    RPCManager.Instance.SetPaused(false);
+            }
         }
 
         private void UnLoadStripMenuItem_Click(object sender, EventArgs e)
@@ -1249,6 +1263,8 @@ namespace ScePSX.UI
 
             Core.PsxBus.controller1.IsAnalog = isAnalog;
 
+            RPCManager.Instance.StartGame(gamename, Core.DiskID);
+
             CheatCode.Enabled = true;
 
             if (sysini != null)
@@ -1287,6 +1303,8 @@ namespace ScePSX.UI
             Core.SwapDisk(FD.FileName);
 
             Core.Pauseing = false;
+
+            RPCManager.Instance.StartGame(Path.GetFileNameWithoutExtension(FD.FileName), Core.DiskID);
 
             UpdateStatus(1, $"{Translations.GetText("FrmMain_SwapDisc")} {Core.DiskID}", true);
             StatusDelay = 3;


### PR DESCRIPTION
Used the [DiscordRichPresence](https://www.nuget.org/packages/DiscordRichPresence) NuGet package by [Lachee](https://github.com/Lachee) to display information about the current state of the emulator and the game being played.

The Discord App ID in `RPCManager` is only a placeholder and needs to be replaced. I created my own application for testing, so for development purposes you can use mine(1482446005763834111). However, for an official release it is recommended to create and use your own Discord application.

The RPC requires one uploaded asset called `logo`. This can be any image, but I used the ScePSX logo.

I will update this post later with a Preview after I have verified the Windows build.

The Android build is currently untested because I am using Arch Linux, and .NET MAUI is not supported on Linux.

Preview images:

<img width="280" height="128" alt="image" src="https://github.com/user-attachments/assets/c6b19325-989d-47ce-b219-5f7fddc84665" />
<img width="273" height="127" alt="image" src="https://github.com/user-attachments/assets/4c0a9568-12f5-4833-acb8-34b4ad008bc8" />

