### PR TITLE
Moved RPC to 3rdParty, added RPC idle state and fixed null reference in Translations

### DIFF
--- a/3rdParty/3rdParty.csproj
+++ b/3rdParty/3rdParty.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>_3rdParty</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DiscordRichPresence" Version="1.6.1.70" />
+  </ItemGroup>
+
+</Project>

--- a/3rdParty/DiscordRPC/RPCManager.cs
+++ b/3rdParty/DiscordRPC/RPCManager.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using DiscordRPC;
 using DiscordRPC.Logging;
 
-namespace ScePSX.Core.DiscordRPC
+namespace ScePSX.ThirdParty.DiscordRPC
 {
     public class RPCManager : IDisposable
     {
@@ -21,7 +21,7 @@ namespace ScePSX.Core.DiscordRPC
         private Stopwatch _playTimeStopwatch;
         private string _platformName = "";
 
-        private const string APP_ID = "1342671514892259388";
+        private const string APP_ID = "1482446005763834111"; //test id, change in prod
 
         public void Initialize()
         {
@@ -54,6 +54,7 @@ namespace ScePSX.Core.DiscordRPC
                 _client.Initialize();
                 _playTimeStopwatch = new Stopwatch();
                 _initialized = true;
+                UpdatePresence();
                 Console.WriteLine("[DiscordRPC] Initialized successfully on {0}", _platformName);
             }
             catch (Exception ex)
@@ -73,7 +74,7 @@ namespace ScePSX.Core.DiscordRPC
             if (OperatingSystem.IsAndroid())
                 return "Android";
             if (OperatingSystem.IsIOS())
-                return "iOS";
+                return "iOS"; //i dont think this will be ever the case but just in case
 
             return RuntimeInformation.OSDescription;
         }
@@ -92,6 +93,7 @@ namespace ScePSX.Core.DiscordRPC
 
         public void SetPaused(bool paused)
         {
+            Console.WriteLine($"[DiscordRPC] SetPaused called: {paused}, initialized: {_initialized}, client: {_client != null}, diskId: '{_diskId}'");
             if (!_initialized || _client == null || string.IsNullOrEmpty(_diskId)) return;
 
             _isPaused = paused;
@@ -124,19 +126,26 @@ namespace ScePSX.Core.DiscordRPC
         {
             if (_client == null) return;
 
+            bool isIdle = string.IsNullOrEmpty(_gameName);
+            bool isInGame = !isIdle && !_isPaused;
+
             var presence = new RichPresence()
             {
-                Details = string.IsNullOrEmpty(_gameName) ? "ScePSX" : _gameName,
-                State = _isPaused ? $"Paused | {_platformName}" : $"{FormatPlayTime(_playTimeStopwatch.Elapsed)} | {_platformName}",
-                Timestamps = _isPaused ? new Timestamps() : new Timestamps(DateTime.UtcNow),
-                Assets = new Assets()
+                Details = isIdle ? "Menu" : _gameName,
+                State = _isPaused ? $"Paused | {_platformName}" : (isIdle ? $"Idle | {_platformName}" : $"{FormatPlayTime(_playTimeStopwatch.Elapsed)} | {_platformName}"),
+                Timestamps = isInGame ? new Timestamps(DateTime.UtcNow) : new Timestamps()
+            };
+
+            if (!isIdle)
+            {
+                presence.Assets = new Assets()
                 {
                     LargeImageKey = "logo",
                     LargeImageText = "PlayStation 1 Emulator",
                     SmallImageKey = _isPaused ? "paused" : "playing",
                     SmallImageText = _isPaused ? "Paused" : "In Game"
-                }
-            };
+                };
+            }
 
             if (!string.IsNullOrEmpty(_diskId))
             {

--- a/AvaloniaUI/ScePSX.csproj
+++ b/AvaloniaUI/ScePSX.csproj
@@ -39,6 +39,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\3rdParty\3rdParty.csproj" />
     <ProjectReference Include="..\ScePSX\Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="lang\lang-pt.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="lang\lang.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/AvaloniaUI/UI/MainWindow.axaml.cs
+++ b/AvaloniaUI/UI/MainWindow.axaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -11,7 +11,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
-using ScePSX.Core.DiscordRPC;
+using ScePSX.ThirdParty.DiscordRPC;
 using ScePSX.Core.GPU;
 
 namespace ScePSX.UI;
@@ -294,7 +294,8 @@ public partial class MainWindow : Window
         foreach (MenuItem child in Menu.Items.OfType<MenuItem>())
             child.IsChecked = false;
 
-        (Menu.Items[CheckIdx] as MenuItem).IsChecked = true;
+        if (CheckIdx >= 0 && CheckIdx < Menu.Items.Count)
+            (Menu.Items[CheckIdx] as MenuItem).IsChecked = true;
     }
 
     private void MainWindow_KeyUp(object? sender, KeyEventArgs e)

--- a/AvaloniaUI/Utils/Translations.cs
+++ b/AvaloniaUI/Utils/Translations.cs
@@ -20,7 +20,7 @@ namespace ScePSX.UI
 
         private static SortedSet<string> _AvailableLanguages;
 
-        public static string DefaultLanguage = "";
+        public static string DefaultLanguage = "en";
 
         public static Dictionary<string, string> Languages = new Dictionary<string, string>();
 

--- a/ScePSX.Avalonia.sln
+++ b/ScePSX.Avalonia.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "ScePSX\Core.csproj"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScePSX", "AvaloniaUI\ScePSX.csproj", "{A284CBA8-2FF5-4A73-9374-84F0F836E811}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "3rdParty", "3rdParty\3rdParty.csproj", "{50665EE0-4C90-6705-A0AA-47709E31B14E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{A284CBA8-2FF5-4A73-9374-84F0F836E811}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A284CBA8-2FF5-4A73-9374-84F0F836E811}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A284CBA8-2FF5-4A73-9374-84F0F836E811}.Release|Any CPU.Build.0 = Release|Any CPU
+		{50665EE0-4C90-6705-A0AA-47709E31B14E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{50665EE0-4C90-6705-A0AA-47709E31B14E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{50665EE0-4C90-6705-A0AA-47709E31B14E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{50665EE0-4C90-6705-A0AA-47709E31B14E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ScePSX.Window.sln
+++ b/ScePSX.Window.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ScePSX.Win", "WindowUI\SceP
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "ScePSX\Core.csproj", "{D5B209D6-4B10-A5C9-1C7D-74897040277E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "3rdParty", "3rdParty\3rdParty.csproj", "{528F7AE4-C245-45D9-B893-995FD9AEF7C9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{D5B209D6-4B10-A5C9-1C7D-74897040277E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D5B209D6-4B10-A5C9-1C7D-74897040277E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D5B209D6-4B10-A5C9-1C7D-74897040277E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{528F7AE4-C245-45D9-B893-995FD9AEF7C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{528F7AE4-C245-45D9-B893-995FD9AEF7C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{528F7AE4-C245-45D9-B893-995FD9AEF7C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{528F7AE4-C245-45D9-B893-995FD9AEF7C9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ScePSX/Core.csproj
+++ b/ScePSX/Core.csproj
@@ -35,7 +35,21 @@
 </ItemGroup>
 
 <ItemGroup>
-  <PackageReference Include="DiscordRichPresence" Version="1.6.1.70" />
+  <None Include="..\LIBS\SDL2\win64\SDL2.dll" Link="SDL2.dll" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </None>
+  <None Include="..\LIBS\SDL2\win64\SDL2.dll" Link="SDL2.dll" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </None>
+  <None Include="..\LIBS\SDL2\armhf\libSDL2.so" Link="libSDL2.so" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </None>
+  <None Include="..\LIBS\SDL2\amd64\libSDL2.so" Link="libSDL2.so" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </None>
+  <None Include="..\LIBS\SDL2\osx\libSDL2.dylib" Link="libSDL2.dylib" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'osx'">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </None>
 </ItemGroup>
 
 </Project>

--- a/WindowUI/Render/VulkanRender.resx
+++ b/WindowUI/Render/VulkanRender.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/WindowUI/ScePSX.Win.csproj
+++ b/WindowUI/ScePSX.Win.csproj
@@ -55,7 +55,20 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\3rdParty\3rdParty.csproj" />
     <ProjectReference Include="..\ScePSX\Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\LIBS\SDL2\win64\SDL2.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="lang\lang-pt.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="lang\lang.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   </Project>

--- a/WindowUI/UI/Form_Main.cs
+++ b/WindowUI/UI/Form_Main.cs
@@ -1,5 +1,5 @@
 using Microsoft.Win32;
-using ScePSX.Core.DiscordRPC;
+using ScePSX.ThirdParty.DiscordRPC;
 using ScePSX.Core.GPU;
 using ScePSX.Render;
 using ScePSX.Win.UI;
@@ -809,11 +809,10 @@ namespace ScePSX.UI
         {
             if (Core != null && Core.Running)
             {
+                bool wasPaused = Core.Pauseed;
                 Core.Pause();
-                if (Core.Pauseed)
-                    RPCManager.Instance.SetPaused(true);
-                else
-                    RPCManager.Instance.SetPaused(false);
+                while (Core.Pauseed == wasPaused) { }
+                RPCManager.Instance.SetPaused(Core.Pauseed);
             }
         }
 
@@ -970,7 +969,10 @@ namespace ScePSX.UI
                 {
                     if (Core.Pauseed)
                         SimpleOSD.Close();
+                    bool wasPaused = Core.Pauseed;
                     Core.Pause();
+                    while (Core.Pauseed == wasPaused) { }
+                    RPCManager.Instance.SetPaused(Core.Pauseed);
                 }
                 return;
             }

--- a/WindowUI/UI/Translations.cs
+++ b/WindowUI/UI/Translations.cs
@@ -18,7 +18,7 @@ namespace ScePSX.UI
 
         private static SortedSet<string> _AvailableLanguages;
 
-        public static string DefaultLanguage = null;
+        public static string DefaultLanguage = "en";
 
         public static Dictionary<string, string> Languages = new Dictionary<string, string>();
 
@@ -246,15 +246,20 @@ namespace ScePSX.UI
             }
             catch (Exception)
             {
-                //Console.Error.WriteLine("Can't find key '{0}.{1}.{2}'", CategoryId, TextId, LangId);
-                //Console.Error.WriteLine(value);
                 try
                 {
-                    result = dictionary[Translations.DefaultLanguage];
+                    if (dictionary != null)
+                    {
+                        result = dictionary[Translations.DefaultLanguage];
+                    }
+                    else
+                    {
+                        result = null;
+                    }
                 }
                 catch
                 {
-                    result = null;//string.Format("{0}.{1}", CategoryId, TextId);
+                    result = null;
                 }
             }
             return result;


### PR DESCRIPTION
* I moved the Discord RPC code to a third-party module
* I fixed an issue where `DefaultLanguage` was `null`, which prevented the application from loading
* I fixed an issue where the SDL2 binary was not copied to the application root

I found and fixed those compilation issues on the most platforms, including the one mentioned earlier. I added logic to each project to copy only the SDL2 binary for the current platform, but it is not fully working yet. Both Linux and Windows binaries are still being copied to the output folder.

I also found issues in Netplay that I have not fixed yet.

I am currently working on party integration for Netplay. This will allow users to join others via Discord game invites. The current build uses my own Application ID in the constant value. You can replace it with your own or keep mine.
