### PR TITLE
Fix Apply button not updating settings or closing dialog

### DIFF
--- a/Android/build.bat
+++ b/Android/build.bat
@@ -1,1 +1,3 @@
 dotnet build -f net8.0-android -c Release
+
+REM Note: Android SDL2 (armhf) is copied via Core.csproj conditional includes

--- a/AvaloniaUI/publish.linux.arm.bat
+++ b/AvaloniaUI/publish.linux.arm.bat
@@ -1,3 +1,5 @@
 dotnet publish -c Release -r linux-arm -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false --self-contained true
 
+copy /Y ..\LIBS\SDL2\armhf\libSDL2.so bin\Release\net8.0\linux-arm\publish\
+
 pause

--- a/AvaloniaUI/publish.linux.arm64.bat
+++ b/AvaloniaUI/publish.linux.arm64.bat
@@ -1,3 +1,5 @@
 dotnet publish -c Release -r linux-arm64 -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false --self-contained true
 
+REM Note: No arm64 libSDL2.so available - requires separate download from SDL website
+
 pause

--- a/AvaloniaUI/publish.linux.loongarch64.bat
+++ b/AvaloniaUI/publish.linux.loongarch64.bat
@@ -1,3 +1,5 @@
 dotnet publish -c Release -r linux-loongarch64 -p:PublishSingleFile=true -p:PublishTrimmed=false -p:DebugType=None -p:DebugSymbols=false --self-contained true -p:RuntimeFrameworkVersion=8.0.22
 
+copy /Y ..\LIBS\SDL2\loongarch64\libSDL2.so bin\Release\net8.0\linux-loongarch64\publish\
+
 pause

--- a/AvaloniaUI/publish.linux.x64.bat
+++ b/AvaloniaUI/publish.linux.x64.bat
@@ -1,3 +1,5 @@
 dotnet publish -c Release -r linux-x64 -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false --self-contained true
 
+copy /Y ..\LIBS\SDL2\amd64\libSDL2.so bin\Release\net8.0\linux-x64\publish\
+
 pause

--- a/AvaloniaUI/publish.osx.osx-arm64.bat
+++ b/AvaloniaUI/publish.osx.osx-arm64.bat
@@ -1,3 +1,5 @@
 dotnet publish -c Release -r osx-arm64 -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false --self-contained true
 
+copy /Y ..\LIBS\SDL2\osx\libSDL2.dylib bin\Release\net8.0\osx-arm64\publish\
+
 pause

--- a/AvaloniaUI/publish.osx.osx-x64.bat
+++ b/AvaloniaUI/publish.osx.osx-x64.bat
@@ -1,3 +1,5 @@
 dotnet publish -c Release -r osx-x64 -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false --self-contained true
 
+copy /Y ..\LIBS\SDL2\osx\libSDL2.dylib bin\Release\net8.0\osx-x64\publish\
+
 pause

--- a/AvaloniaUI/publish.win.x64.bat
+++ b/AvaloniaUI/publish.win.x64.bat
@@ -1,3 +1,5 @@
 dotnet publish -c Release -r win-x64 -p:PublishSingleFile=true -p:PublishTrimmed=true -p:DebugType=None -p:DebugSymbols=false --self-contained true
 
+copy /Y ..\LIBS\SDL2\win64\SDL2.dll bin\Release\net8.0\win-x64\publish\
+
 pause

--- a/ScePSX/Core.csproj
+++ b/ScePSX/Core.csproj
@@ -35,21 +35,7 @@
 </ItemGroup>
 
 <ItemGroup>
-  <None Include="..\LIBS\SDL2\win64\SDL2.dll" Link="SDL2.dll" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">
-    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-  </None>
-  <None Include="..\LIBS\SDL2\win64\SDL2.dll" Link="SDL2.dll" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
-    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-  </None>
-  <None Include="..\LIBS\SDL2\armhf\libSDL2.so" Link="libSDL2.so" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
-    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-  </None>
-  <None Include="..\LIBS\SDL2\amd64\libSDL2.so" Link="libSDL2.so" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">
-    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-  </None>
-  <None Include="..\LIBS\SDL2\osx\libSDL2.dylib" Link="libSDL2.dylib" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'osx'">
-    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-  </None>
+
 </ItemGroup>
 
 </Project>

--- a/WindowUI/ScePSX.Win.csproj
+++ b/WindowUI/ScePSX.Win.csproj
@@ -60,9 +60,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\LIBS\SDL2\win64\SDL2.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <None Update="lang\lang-pt.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/WindowUI/UI/Form_Main.cs
+++ b/WindowUI/UI/Form_Main.cs
@@ -1087,7 +1087,7 @@ namespace ScePSX.UI
                 Core.Button(button1, false, 1);
         }
 
-        private void applypgxp()
+        public void applypgxp()
         {
             PGXPVector.use_pgxp = ini.ReadInt("PGXP", "base") == 1;
             PGXPVector.use_pgxp_aff = ini.ReadInt("PGXP", "aff") == 1;

--- a/WindowUI/UI/Form_Set.cs
+++ b/WindowUI/UI/Form_Set.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Windows.Forms;
 
@@ -90,6 +90,8 @@ namespace ScePSX.UI
             }
 
             applypgxp();
+            FrmMain.applypgxp();
+            this.Close();
         }
 
         private void btndel_Click(object sender, EventArgs e)


### PR DESCRIPTION
* Resolved an issue where BtnSave in the options dialog produced no visible effect
* Added a call to applypgxp() after saving to reload settings in the main form
* Closed the options dialog after saving to provide user feedback
* Made applypgxp() public to allow invocation from Form_Set

In the previous commit, I also changed how the SDL2 binaries are copied. All batch files except arm64 now copy the SDL2 binaries after publishing for the proper platform. Although you mentioned earlier that the core project should remain clean, I still recommend using a NuGet package for the SDL2 implementation so we do not have to handle copying the SDL2 binaries manually. Maybe put the Package also in ThirdParty?

I am also currently working on a separate branch for workflows to build ScePSX for all platforms (See [git-workflow](https://github.com/ExilProductions/ScePSX/tree/git-workflow)). I may create a PR once I finalize each workflow.
